### PR TITLE
Feature/node auth

### DIFF
--- a/other/js/auth_plugin_examples.js
+++ b/other/js/auth_plugin_examples.js
@@ -10,9 +10,20 @@
  */
 
 const querystring = require('querystring');
-fs = require('fs');
+const fs = require('fs');
 
 function urlTokenMatch(url, token, verbose=false) {
+    /**
+     * Parse the url path, extract the `token` querystring value, and check if
+     * it matches the token argument. If verbose is set to true, log messages
+     * are enabled.
+     *
+     * Args:
+     *      url (string): the path section of the URL
+     *      token (string): the token which the token provided in the URL should
+     *          match
+     *      verbose (boolean): If True, extra console.log messages will be output
+     */
     let splitUrl = url.split("?")
     if (splitUrl.length !== 2) {
         if (verbose) {
@@ -34,6 +45,11 @@ function urlTokenMatch(url, token, verbose=false) {
 }
 
 exports.tokenAuth = function tokenAuth(source) {
+    /**
+     * Authorisation plugin which validates the token query parameter against
+     * a token provided as the argument to the --auth-source command line
+     * argument
+     */
     return function(info) {
         let token = source;
         return urlTokenMatch(info.req.url, token, true);
@@ -41,6 +57,12 @@ exports.tokenAuth = function tokenAuth(source) {
 }
 
 exports.tokenAuthEnv = function tokenAuthEnv(source) {
+    /**
+     * Authorisation plugin which validates the token query parameter against
+     * a token which is the value of an environment variable. The name of this
+     * environment variable is specified as the argument to the command line
+     * argument --auth-source
+     */
     return function(info) {
         let token = process.env[source];
         return urlTokenMatch(info.req.url, token, true);
@@ -48,6 +70,11 @@ exports.tokenAuthEnv = function tokenAuthEnv(source) {
 }
 
 exports.tokenAuthFile = function tokenEnvFile(source) {
+    /**
+     * Authorisation plugin which validates the token query parameter against a
+     * token which is contained in a text file, the path to which is specified
+     * as the value of the --auth-source command line argument
+     */
     return function(info, cb) {
         fs.readFile(source, 'utf8', function(err, data) {
             if (err) {

--- a/other/js/auth_plugin_examples.js
+++ b/other/js/auth_plugin_examples.js
@@ -47,8 +47,8 @@ function urlTokenMatch(url, token, verbose=false) {
 exports.tokenAuth = function tokenAuth(source) {
     /**
      * Authorisation plugin which validates the token query parameter against
-     * a token provided as the argument to the --auth-source command line
-     * argument
+     * a token provided as the argument to the `--auth-source` command line
+     * argument.
      */
     return function(info) {
         let token = source;
@@ -61,7 +61,7 @@ exports.tokenAuthEnv = function tokenAuthEnv(source) {
      * Authorisation plugin which validates the token query parameter against
      * a token which is the value of an environment variable. The name of this
      * environment variable is specified as the argument to the command line
-     * argument --auth-source
+     * argument `--auth-source`
      */
     return function(info) {
         let token = process.env[source];
@@ -73,7 +73,7 @@ exports.tokenAuthFile = function tokenEnvFile(source) {
     /**
      * Authorisation plugin which validates the token query parameter against a
      * token which is contained in a text file, the path to which is specified
-     * as the value of the --auth-source command line argument
+     * as the value of the `--auth-source` command line argument
      */
     return function(info, cb) {
         fs.readFile(source, 'utf8', function(err, data) {

--- a/other/js/auth_plugin_examples.js
+++ b/other/js/auth_plugin_examples.js
@@ -1,0 +1,27 @@
+/*
+ * An auth plugin must be a function which returns a function conforing to the
+ * requirements of the `verifyClients` option on ws.WebSocket.Server.
+ *
+ * See: https://github.com/websockets/ws/blob/master/doc/ws.md
+ *
+ * If websockify is provided with an --auth-source argument, this will be
+ * passed to the auth plugin as its first argument.
+ *
+ */
+
+const querystring = require('querystring');
+
+exports.tokenAuth = function tokenAuth(source) {
+    return function(info) {
+        console.log(info.req.url);
+        let splitUrl = info.req.url.split("?")
+        if (splitUrl.length !== 2) {
+            return false;
+        }
+        let qs = splitUrl[1];
+        let qs_parsed = querystring.parse(qs)
+        console.log(qs_parsed)
+        return (qs_parsed.token === source);
+    }
+}
+

--- a/other/js/auth_plugin_examples.js
+++ b/other/js/auth_plugin_examples.js
@@ -15,7 +15,10 @@ fs = require('fs');
 function urlTokenMatch(url, token, verbose=false) {
     let splitUrl = url.split("?")
     if (splitUrl.length !== 2) {
-        return ["", false];
+        if (verbose) {
+            console.log("Permission denied. No token provided.");
+        }
+        return false;
     }
     let qs = splitUrl[1];
     let qs_parsed = querystring.parse(qs);

--- a/other/js/auth_plugin_examples.js
+++ b/other/js/auth_plugin_examples.js
@@ -10,6 +10,7 @@
  */
 
 const querystring = require('querystring');
+fs = require('fs');
 
 function urlTokenMatch(url, token, verbose=false) {
     let splitUrl = url.split("?")
@@ -40,5 +41,20 @@ exports.tokenAuthEnv = function tokenAuthEnv(source) {
     return function(info) {
         let token = process.env[source];
         return urlTokenMatch(info.req.url, token, true);
+    }
+}
+
+exports.tokenAuthFile = function tokenEnvFile(source) {
+    return function(info, cb) {
+        fs.readFile(source, 'utf8', function(err, data) {
+            if (err) {
+                console.log(err);
+                cb(false);
+            } else {
+                let token = data.trim();
+                let success = urlTokenMatch(info.req.url, token, true);
+                cb(success);
+            }
+        });
     }
 }

--- a/other/js/auth_plugin_examples.js
+++ b/other/js/auth_plugin_examples.js
@@ -11,17 +11,34 @@
 
 const querystring = require('querystring');
 
+function urlTokenMatch(url, token, verbose=false) {
+    let splitUrl = url.split("?")
+    if (splitUrl.length !== 2) {
+        return ["", false];
+    }
+    let qs = splitUrl[1];
+    let qs_parsed = querystring.parse(qs);
+    let success = (qs_parsed.token === token);
+    if (verbose) {
+        if (!success) {
+            console.log("Permission denied for token: " + qs_parsed.token);
+        } else {
+            console.log("Permission granted for token: " + qs_parsed.token);
+        }
+    }
+    return success;
+}
+
 exports.tokenAuth = function tokenAuth(source) {
     return function(info) {
-        console.log(info.req.url);
-        let splitUrl = info.req.url.split("?")
-        if (splitUrl.length !== 2) {
-            return false;
-        }
-        let qs = splitUrl[1];
-        let qs_parsed = querystring.parse(qs)
-        console.log(qs_parsed)
-        return (qs_parsed.token === source);
+        let token = source;
+        return urlTokenMatch(info.req.url, token, true);
     }
 }
 
+exports.tokenAuthEnv = function tokenAuthEnv(source) {
+    return function(info) {
+        let token = process.env[source];
+        return urlTokenMatch(info.req.url, token, true);
+    }
+}

--- a/other/js/password.txt
+++ b/other/js/password.txt
@@ -1,0 +1,1 @@
+passpass12

--- a/other/js/password.txt
+++ b/other/js/password.txt
@@ -1,1 +1,0 @@
-passpass12


### PR DESCRIPTION
I have adapted the node.js version of Websockify, to take advantage of the `ws` library's authorization capabilities. Authorisation plugins can now be specified using the `--auth-plugin` and `--auth-source` command line arguments. `--auth-plugin` specifies the `<module>.<member>` function to use as an auth plugin. `--auth-source` provides additional configuration as a string, which is passed as the first argument to the plugin function. This command line format mirrors that in the Python version of websockify.

Authorisation plugins are functions that take a `source` argument, and return a function that can be used as the `verifyClient` option to the `ws.WebSocket.Server` class from https://github.com/websockets/ws.

The following abridged extract from the `ws` module documentation at https://github.com/websockets/ws/blob/master/doc/ws.md should clarify:

> 
> ### new WebSocket.Server(options[, callback])
> 
> - `options` {Object}
>   ...
>   - `verifyClient` {Function} A function which can be used to validate incoming
>     connections. See description below.
>
>   ...
> - `callback` {Function}
> 
> Create a new server instance. One of `port`, `server` or `noServer` must be
> provided or an error is thrown.
> 
> 
> If `verifyClient` is not set then the handshake is automatically accepted. If
> it is is provided with a single argument then that is:
> 
> - `info` {Object}
>   - `origin` {String} The value in the Origin header indicated by the client.
>   - `req` {http.IncomingMessage} The client HTTP GET request.
>   - `secure` {Boolean} `true` if `req.connection.authorized` or
>     `req.connection.encrypted` is set.
> 
> The return value (Boolean) of the function determines whether or not to accept
> the handshake.
> 
> if `verifyClient` is provided with two arguments then those are:
> 
> - `info` {Object} Same as above.
> - `cb` {Function} A callback that must be called by the user upon inspection
>   of the `info` fields. Arguments in this callback are:
>   - `result` {Boolean} Whether or not to accept the handshake.
>   - `code` {Number} When `result` is `false` this field determines the HTTP
>     error status code to be sent to the client.
>   - `name` {String} When `result` is `false` this field determines the HTTP
>     reason phrase.

The only relevant files are under `other/js`. The node version of websockify is standalone, and the rest of the repo is therefore irrelevant to this pull request, and does not need to be read to understand what is going on.